### PR TITLE
Bump annict-kt from 2.2.0 to 2.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ object ThirdpartyVersion {
     const val Ktor = "1.5.0"
     const val JsonKt = "6.0.0"
     const val Jsoup = "1.13.1"
-    const val AnnictKt = "2.2.0"
+    const val AnnictKt = "2.4.2"
     const val Penicillin = "6.0.2"
     const val ApacheCommonsCodec = "1.15"
     const val KtorSwagger = "0.7.0"


### PR DESCRIPTION
開発お疲れ様です。
[annict-kt](https://github.com/iam-takagi/annict-kt) v[2.4.2](https://github.com/iam-takagi/annict-kt/releases/tag/2.4.2) リリースされましたので 移行お願いします。