### PR TITLE
30分を超えるタイムシフトの際に30分以降コメントが流れないのを修正

### DIFF
--- a/src/main/kotlin/blue/starry/saya/services/miyoutv/TimeshiftMiyouTVResProvider.kt
+++ b/src/main/kotlin/blue/starry/saya/services/miyoutv/TimeshiftMiyouTVResProvider.kt
@@ -34,7 +34,8 @@ class TimeshiftMiyouTVResProvider(
                         try {
                             return@async fetchCommentsInRangeOf(
                                 startAt = (startAt + unit * index) * 1000,
-                                endAt = minOf(startAt + unit * (index + 1), endAt) * 1000
+                                endAt = minOf(startAt + unit * (index + 1), endAt) * 1000,
+                                offset = unit * index * 1000
                             )
                         } catch (e: CancellationException) {
                             break
@@ -54,10 +55,10 @@ class TimeshiftMiyouTVResProvider(
         }
     }
 
-    private suspend fun fetchCommentsInRangeOf(startAt: Long, endAt: Long): List<Comment> {
+    private suspend fun fetchCommentsInRangeOf(startAt: Long, endAt: Long, offset: Int): List<Comment> {
         return api.getComments(id, startAt, endAt).data.comments.map {
             it.toSayaComment(
-                seconds = it.time / 1000.0 - startAt
+                seconds = it.time / 1000.0 - startAt + offset
             )
         }
     }

--- a/src/main/kotlin/blue/starry/saya/services/nicolive/TimeshiftNicoliveCommentProvider.kt
+++ b/src/main/kotlin/blue/starry/saya/services/nicolive/TimeshiftNicoliveCommentProvider.kt
@@ -33,7 +33,8 @@ class TimeshiftNicoliveCommentProvider(
                         try {
                             return@async fetchCommentsInRangeOf(
                                 startAt = startAt + unit * index,
-                                endAt = minOf(startAt + unit * (index + 1) - 1, endAt)
+                                endAt = minOf(startAt + unit * (index + 1) - 1, endAt),
+                                offset = unit * index
                             )
                         } catch (e: CancellationException) {
                             break
@@ -53,7 +54,7 @@ class TimeshiftNicoliveCommentProvider(
         }
     }
 
-    private suspend fun fetchCommentsInRangeOf(startAt: Long, endAt: Long): List<Comment> {
+    private suspend fun fetchCommentsInRangeOf(startAt: Long, endAt: Long, offset: Int): List<Comment> {
         return NicoJkApi.getComments("jk${channel.nicojkId}", startAt, endAt)
             .packets
             .asSequence()
@@ -63,7 +64,7 @@ class TimeshiftNicoliveCommentProvider(
                 it.toSayaComment(
                     source = "ニコニコ実況過去ログAPI [jk${channel.nicojkId}]",
                     sourceUrl = "https://jikkyo.tsukumijima.net/api/kakolog/jk${channel.nicojkId}?starttime=${it.date}&endtime=${it.date + 1}&format=json",
-                    seconds = ((it.date * 1000 + it.dateUsec / 1000) - startAt * 1000) / 1000.0
+                    seconds = ((it.date * 1000 + it.dateUsec / 1000) - startAt * 1000) / 1000.0 + offset
                 )
             }
             .toList()


### PR DESCRIPTION
## 概要
`TimeshiftNicoliveCommentProvider` / `TimeshiftMiyouTVResProvider` にて複数にリクエストを分けて取得している部分で、seconds が startAt のみから計算されているので、全てのコメントが 0-30 分に集約されてしまうバグを修正する

## 注意点
MiyouTV の方の seconds 計算が正しいか怪しい
